### PR TITLE
:memo: 庄のの月曜限定ラーメン情報を追加

### DIFF
--- a/市ヶ谷.md
+++ b/市ヶ谷.md
@@ -9,6 +9,7 @@
 毎月22日は魂心家の日で500円。行列注意。
 + [九段 斑鳩](https://ramendb.supleks.jp/s/89589.html)
 + [麺や 庄の](https://ramendb.supleks.jp/s/4391.html)
+月曜限定 灼熱辛味噌らーめん
 + [大塚屋](https://ramendb.supleks.jp/s/86118.html)
 + [麺屋 いまむら](https://ramendb.supleks.jp/s/76527.html)
 + [火の国らーめん てっぺん](https://ramendb.supleks.jp/s/11334.html)


### PR DESCRIPTION
庄の食べてきた。ここのたまごかけご飯はネギに鰹節・醤油の組み合わせでユーザ体験高め。